### PR TITLE
Fix for weights_ty=<SparseType.FP16: 'fp16'>, output_dtype=<SparseType.BF16: 'bf16'>

### DIFF
--- a/fbgemm_gpu/codegen/embedding_forward_split_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_split_cpu.cpp
@@ -410,6 +410,8 @@ void csr2csc_template_(
 
   int max_thds = omp_get_max_threads();
   int num_uniq[max_thds][64];
+  for( int i = 0 ; i < max_thds; i++ )
+	  num_uniq[i][0] = 0;
 
   int U = 0;
   if (at::get_num_threads() > 1) {

--- a/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
@@ -1517,11 +1517,13 @@ DEVICE_INLINE __nv_bfloat162 to_bfloat16_2(float2 v) {
 #else
   union {
     __nv_bfloat162 raw;
-    __nv_bfloat16 x;
-    __nv_bfloat16 y;
+    struct {
+      __nv_bfloat16 x;
+      __nv_bfloat16 y;
+    } split;
   } t;
-  t.x = __float2bfloat16_rn(v.x);
-  t.y = __float2bfloat16_rn(v.y);
+  t.split.x = __float2bfloat16_rn(v.x);
+  t.split.y = __float2bfloat16_rn(v.y);
   return t.raw;
 #endif
 }

--- a/fbgemm_gpu/src/cumem_utils.cu
+++ b/fbgemm_gpu/src/cumem_utils.cu
@@ -422,7 +422,11 @@ Tensor uvm_to_cpu_clone(const Tensor& t) {
   return cpu_clone;
 }
 
-FBGEMM_GPU_ENUM_GLOGAL(uvm)
+//FBGEMM_GPU_ENUM_GLOGAL(uvm)
+  template class enum_registration<struct fbgemm_gpu_enum_tag_uvm>;
+    template <>
+      enum_registration<struct fbgemm_gpu_enum_tag_uvm>*
+            enum_registration<struct fbgemm_gpu_enum_tag_uvm> ::registration_list = nullptr;
 
 FBGEMM_GPU_ENUM_REGISTER_START(uvm, cudaMemory, Advise){
     FBGEMM_GPU_ENUM_ITEM(

--- a/fbgemm_gpu/src/cumem_utils.h
+++ b/fbgemm_gpu/src/cumem_utils.h
@@ -81,6 +81,13 @@ void uvm_mem_advice_dont_fork(const Tensor& t);
 /// The copy uses single threaded memcpy
 Tensor uvm_to_cpu_clone(const Tensor& t);
 
-FBGEMM_GPU_ENUM_CREATE_TAG(uvm)
+//FBGEMM_GPU_ENUM_CREATE_TAG(uvm)
+  struct fbgemm_gpu_enum_tag_uvm {};
+  template <>                                                           \
+  enum_registration<struct fbgemm_gpu_enum_tag_uvm>*          \
+      enum_registration<                                                \
+          struct fbgemm_gpu_enum_tag_uvm>::registration_list;
+  extern template class enum_registration<                              \
+      struct fbgemm_gpu_enum_tag_uvm>;
 
 } // namespace fbgemm_gpu


### PR DESCRIPTION
* Fix for weights_ty=<SparseType.FP16: 'fp16'>, output_dtype=<SparseType.BF16: 'bf16'>
* Expanded ENUM to fix `error: explicit specialization of 'registration_list' after instantiation` on ROCm5.4 (@liligwu , please discuss with me and if this is a bug on ROCm, lets open a JIRA). 